### PR TITLE
fixed to_uri_string and print_prefixes of expxml2ttl.py

### DIFF
--- a/python/script/expxml2ttl.py
+++ b/python/script/expxml2ttl.py
@@ -42,7 +42,7 @@ def print_prefixes():
 
 
 def to_uri_string(s):
-    return urllib.parse.quote_plus(re.sub("\s", "_", s))
+    return urllib.parse.quote_plus(re.sub("\s", "_", s.strip()))
 
 
 def escape_string(s):

--- a/python/script/expxml2ttl.py
+++ b/python/script/expxml2ttl.py
@@ -36,7 +36,8 @@ def print_prefixes():
     print("@prefix : <http://ddbj.nig.ac.jp/ontologies/dra/> .")
     print("@prefix id: <http://identifiers.org/insdc.sra/> .")
     print("@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .")
-    print("@prefix dct: <http://purl.obolibrary.org/obo/> .")
+    print("@prefix dct: <http://purl.org/dc/terms/> .")
+
     print("")
 
 


### PR DESCRIPTION
元の xml で
`<INSTRUMENT_MODEL>Illumina MiSeq  </INSTRUMENT_MODEL>`
のように不要なスペースが入ってしまっていることがあり、expxml2ttl.py がこれを URI に変換する際にアンダーバーに置換してしまっていました。
置換する前に末尾のスペースを strip するように修正しました。
また、dct が
`@prefix dct: <http://purl.obolibrary.org/obo/> .`
になっていたので直しました。
